### PR TITLE
Fix non admins being unable to create residences

### DIFF
--- a/src/com/bekvon/bukkit/residence/protection/ClaimedResidence.java
+++ b/src/com/bekvon/bukkit/residence/protection/ClaimedResidence.java
@@ -58,7 +58,7 @@ public class ClaimedResidence {
         }
         if(!Residence.getPermissionManager().isResidenceAdmin(player))
         {
-            if (!area.getWorld().getName().equals(perms.getWorld())) {
+            if (!area.getWorld().getName().toLowerCase().equals(perms.getWorld())) {
                 player.sendMessage("§cArea is in a different world from residence.");
                 return;
             }
@@ -83,7 +83,7 @@ public class ClaimedResidence {
                 player.sendMessage("§cYou've reached the max physical areas allowed for your residence.");
                 return;
             }
-            if(parent==null)
+            if(parent==null && Residence.getConfig().buySellEnabled())
             {
                 int chargeamount = (int) Math.ceil((double)area.getSize() * group.getCostPerBlock());
                 if(!TransactionManager.chargeEconomyMoney(player, chargeamount, "new residence area"))


### PR DESCRIPTION
There was 2 bugs
1. worlds internally you save is as lowercase(I recommend against this), but the check was being done vs directly which wasn't lowercase

Should just use world names as is
1. After the above fix it was trying to force use of an economy and didn't check the config
