### PR TITLE
WorldEdit support - Version update to 2.5.7

### DIFF
--- a/src/com/bekvon/bukkit/residence/Residence.java
+++ b/src/com/bekvon/bukkit/residence/Residence.java
@@ -272,7 +272,7 @@ public class Residence extends JavaPlugin {
                 if(!this.isEnabled())
                     return;
                 FlagPermissions.initValidFlags();
-                smanager = new SelectionManager();
+                smanager = new SelectionManager(server);
                 blistener = new ResidenceBlockListener();
                 plistener = new ResidencePlayerListener();
                 elistener = new ResidenceEntityListener();
@@ -716,6 +716,9 @@ public class Residence extends JavaPlugin {
                         } else if (args[1].equals("chunk")) {
                             smanager.selectChunk(player);
                             return true;
+                        } else if (args[1].equals("worldedit")) {
+                        	smanager.worldEdit(player);
+                        	return true;
                         }
                     } else if (args.length == 3) {
                         if (args[1].equals("expand")) {

--- a/src/com/bekvon/bukkit/residence/selection/SelectionManager.java
+++ b/src/com/bekvon/bukkit/residence/selection/SelectionManager.java
@@ -8,12 +8,20 @@ package com.bekvon.bukkit.residence.selection;
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.permissions.PermissionGroup;
 import com.bekvon.bukkit.residence.protection.CuboidArea;
+import com.sk89q.worldedit.bukkit.WorldEditPlugin;
+import com.sk89q.worldedit.bukkit.selections.Selection;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import org.bukkit.Chunk;
 import org.bukkit.Location;
+import org.bukkit.Server;
 import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
 
 /**
  *
@@ -22,18 +30,29 @@ import org.bukkit.entity.Player;
 public class SelectionManager {
     private Map<String,Location> playerLoc1;
     private Map<String,Location> playerLoc2;
+    private boolean worldEditEnabled = false;
+    private Server server;
 
     public static final int MAX_HEIGHT = 255,MIN_HEIGHT = 0;
-
+    
     public enum Direction
     {
         UP,DOWN,PLUSX,PLUSZ,MINUSX,MINUSZ
     }
 
-    public SelectionManager()
+    public SelectionManager(Server server)
     {
+    	this.server = server;
         playerLoc1 = Collections.synchronizedMap(new HashMap<String,Location>());
         playerLoc2 = Collections.synchronizedMap(new HashMap<String,Location>());
+        Plugin p = server.getPluginManager().getPlugin("WorldEdit");
+        if(p!=null){
+        	worldEditEnabled = true;
+        	Logger.getLogger("Minecraft").log(Level.INFO, "[Residence] Found WorldEdit");
+        } else {
+        	worldEditEnabled = false;
+        	Logger.getLogger("Minecraft").log(Level.INFO, "[Residence] WorldEdit NOT found!");
+        }
     }
 
     public void placeLoc1(String player, Location loc)
@@ -189,6 +208,20 @@ public class SelectionManager {
         this.playerLoc2.put(player.getName(), new Location(player.getWorld(), xmax,ymax,zmax));
         player.sendMessage("§a"+Residence.getLanguage().getPhrase("SelectionSuccess"));
     }
+
+	public void worldEdit(Player player) {
+		// TODO Auto-generated method stub
+		if (worldEditEnabled){
+		WorldEditPlugin wep = (WorldEditPlugin) server.getPluginManager().getPlugin("WorldEdit");
+		Selection sel = wep.getSelection(player);
+		this.playerLoc1.put(player.getName(), sel.getMinimumPoint());
+		this.playerLoc2.put(player.getName(), sel.getMaximumPoint());
+		player.sendMessage("§a"+Residence.getLanguage().getPhrase("SelectionSuccess"));
+		}
+		else {
+			player.sendMessage("§c"+Residence.getLanguage().getPhrase("WorldEditNotFound"));
+		}
+	}
 
     public void selectBySize(Player player, int xsize, int ysize, int zsize) {
         Location myloc = player.getLocation();

--- a/src/languagefiles/English.yml
+++ b/src/languagefiles/English.yml
@@ -175,6 +175,7 @@ Language:
     #Version 18 New Fields
     SelectTooHigh: Warning, selection went above top of map, limiting.
     SelectTooLow: Warning, selection went below bottom of map, limiting.
+    WorldEditNotFound: WorldEdit was not detected.
     
     #The below lines are mostly a word bank for various uses.
     #Version 1 Fields
@@ -287,6 +288,11 @@ CommandHelp: #this is just a holder node, that holds the entire help
                             Info:
                                 - 'Usage /res select <Residence> <AreaID>'
                                 - 'Selects a existing area in a residence.'
+                        worldedit:
+                            Description: Set selection using the current WorldEdit selection.
+                            Info:
+                                - 'Usage /res select worldedit'
+                                - 'Sets selection area using the current WorldEdit selection.'
                 create: #creation command
                     Description: Create Residences
                     Info:

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,9 +1,9 @@
 name: Residence
 main: com.bekvon.bukkit.residence.Residence
-version: 2.5.6
+version: 2.5.7
 description: Cuboid Residence Plugin
 author: bekvon
-softdepend: [Vault,Essentials,RealPlugin,BOSEconomy,iConomy,bPermissions,PermissionsBukkit,Permissions]
+softdepend: [Vault,Essentials,RealPlugin,BOSEconomy,iConomy,bPermissions,PermissionsBukkit,Permissions,WorldEdit]
 commands:
   res:
     description: Manage Residences


### PR DESCRIPTION
WorldEdit support added.  Tested with and without WorldEdit enabled.

Command added:
/res select worldedit
- Will set Residence selection to be the user's WorldEdit selection.
