### PR TITLE
Fix for multiple chat plugins interactions

### DIFF
--- a/src/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
+++ b/src/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
@@ -425,7 +425,7 @@ public class ResidencePlayerListener implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL)
     public void onPlayerChat(PlayerChatEvent event) {
-        if(event.isCancelled()){return;}        
+        if(event.isCancelled()){return;}       
         String pname = event.getPlayer().getName();
         if(chatenabled && playerToggleChat.contains(pname))
         {


### PR DESCRIPTION
Several plugins utilize the event system and cancel events when their plugin highjacks the chat event. i added a check to the playerchatevent to see if the event was cancelled and return. 
