### PR TITLE
/res tp Permissions Node

### DIFF
--- a/src/com/bekvon/bukkit/residence/Residence.java
+++ b/src/com/bekvon/bukkit/residence/Residence.java
@@ -1418,7 +1418,6 @@ public class Residence extends JavaPlugin {
                     if (args.length != 2) {
                         return false;
                     }
-                    System.out.println( "PERM: " + Residence.getPermissionManager().hasAuthority(player, "residence.teleport") );
                     if ( Residence.getPermissionManager().hasAuthority(player, "residence.teleport") ) {
                     	ClaimedResidence res = rmanager.getByName(args[1]);
                     	if (res == null) {


### PR DESCRIPTION
This pull request includes a small patch to allow specifying a 'residence.teleport' permission that controls a player's ability to use '/res tp' Given this new permission node, overall teleportation can be enabled/disabled, on a player-, group-, and/or world-basis.

The original motivation behind this patch was to keep The End as close as possible to Notch's vision. Unfortunately, Residence configuration options don't provide the ability to set the CanTeleport ability on a world-by-world basis. This allows players owning residences to use '/res tp' to escape The End without completing it, or getting killed.

Having the ability to control general teleportation via 'residence.teleport' provides maximum flexibility to handle this, or similar, needs.

Best regards,

Frelling
