### PR TITLE
Override -move Flag

### DIFF
--- a/src/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
+++ b/src/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
@@ -439,7 +439,7 @@ public class ResidencePlayerListener implements Listener {
             }
             return;
         }
-        if (!res.getPermissions().playerHas(pname, "move", true) && !Residence.isResAdminOn(player)) {
+        if (!res.getPermissions().playerHas(pname, "move", true) && !Residence.isResAdminOn(player) && !player.hasPermission("residence.admin.move")) {
             Location lastLoc = lastOutsideLoc.get(pname);
             if (lastLoc != null) {
                 player.teleport(lastLoc);

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -34,6 +34,9 @@ permissions:
   residence.admin.tp:
     description: Allows to override tp flag
     default: op
+  residence.admin.move:
+    description: Allows to override move flag
+    default: op
   residence.create:
     description: Allows you to create residences
     default: op


### PR DESCRIPTION
It would be beneficial if a **residence.admin.move** permission were supported to allow players to enter move-restricted residences, similar to what **residence.admin.tp** does for tp-restricted residences.

It would help our moderators greatly while silently monitoring griefers and cheaters without having to give them full /resadmin privileges, which is just too powerful to give to anyone but a select set of individuals.
