### PR TITLE
Fixed ResidenceEnter/Leave Event for /resadmin Players

### DIFF
--- a/src/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
+++ b/src/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
@@ -353,9 +353,12 @@ public class ResidencePlayerListener implements Listener {
     public void onPlayerTeleport(PlayerTeleportEvent event) {
         Location loc = event.getTo();
         Player player = event.getPlayer();
+        
         if (Residence.isResAdminOn(player)) {
+            handleNewLocation(player, loc, false);
             return;
         }
+        
         ClaimedResidence res = Residence.getResidenceManager().getByLoc(loc);
         if (event.getCause() == TeleportCause.ENDER_PEARL) {
             if (res != null) {


### PR DESCRIPTION
Player having /resadmin privileges were not firing Enter/Leave events until they physically moved. This patch ensures that handleNewLocation is called for all types of players.
