### PR TITLE
Feature Request: ResidenceChangedEvent

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,68 +1,95 @@
 <project name="Residence" default="main" basedir=".">
-  <!-- env variables -->
-  <property name="target" location="target/"/>
-  <property name="Ver" value="2.6.6.5"/>
-  <property name="Authors" value="bekvon,nate302,t00thpick1"/>
-  <property name="Former Authors" value="inorixu,lemon42,smbarbour"/>
-  <path id="classpath"><fileset dir="lib" includes="**/*.jar"/></path>
-  <target name="main" depends="prep, class, compile, jar" description="Main target">
-      <echo>Building the .jar file.</echo>
-  </target>
-  
-  <!-- Prep -->
-  <target name="prep" description="Cleans project">
-    <echo>Cleaning</echo>
-    <delete failonerror="false"><fileset dir="build" includes="**/*"/></delete>
-    <delete file="dist/Residence.jar" />
-    <tstamp/>
-    <delete dir="build"/>
-    <delete dir="lib"/>
-    <mkdir dir="dist"/>
-    <mkdir dir="build"/>
-    <mkdir dir="lib"/>
-  </target>
-  
-  <!-- Download and unzip libraries -->
-  <target name="class">
-    <get src="http://www.whiskeycraft.net/repo/org/spout/spoutapi/spoutpluginapi.jar" dest="lib/SpoutpluginAPI.jar"/>
-    <get src="http://dev.bukkit.org/media/files/658/548/Essentials.zip" dest="lib/Essentials.zip"/> <!--essentials core -->
-    <get src="http://cloud.github.com/downloads/essentials/Essentials/Essentials-gm-2.9.5.zip" dest="lib/GroupManager.zip"/> <!-- essentials group manager and bridge-->
-    <get src="http://dl.bukkit.org/latest-dev/bukkit.jar" dest="lib/Bukkit.jar"/>
-    <get src="http://palmergames.com/downloads/iCo501/iConomy.jar" dest="lib/iConomy5.jar"/>
-    <get src="http://dev.bukkit.org/media/files/575/485/iConomy.jar" dest="lib/iConomy6.jar"/>
-    <get src="http://www.whiskeycraft.net/repo/com/nijikokun/bukkit/permissions/Permissions.jar" dest="lib/Permissions.jar"/>
-    <get src="http://www.whiskeycraft.net/repo/com/platymuus/bukkit-permissions/1.5/bukkit-permissions-1.5.jar" dest="lib/PermissionsBukkit.jar"/>
-    <get src="http://dev.bukkit.org/media/files/656/592/Vault.jar" dest="lib/Vault.jar"/>
-    <get src="http://dev.bukkit.org/media/files/644/439/worldedit-5.4.5.zip" dest="lib/WorldEdit.zip"/>
-    <get src="http://dev.bukkit.org/media/files/577/409/BOSEcon0731.zip" dest="lib/BOSEconomy.zip"/>
-    <get src="http://dev.bukkit.org/media/files/644/317/RealPlugin.jar" dest="lib/RealPlugin.jar"/>
-    <get src="http://dev.bukkit.org/media/files/610/407/bpermissions.jar" dest="lib/bPermissions.jar"/>
-    <unzip src="lib/BOSEconomy.zip" dest="lib/"></unzip>
-    <delete file="lib/BOSEconomy.zip"/>
-    <unzip src="lib\Essentials.zip" dest="lib\Essentials.jar"><patternset><include name="Essentials.jar"/></patternset></unzip>
-    <unzip src="lib\GroupManager.zip" dest="lib\"><patternset><include name="*.jar"/></patternset></unzip>
-    <unzip src="lib\WorldEdit.zip" dest="lib\"><patternset><include name="*.jar"/></patternset></unzip>
-  </target>
+	<!-- env variables -->
+	<property name="target" location="target/" />
+	<property name="Ver" value="2.6.6.5" />
+	<property name="Authors" value="bekvon,nate302,t00thpick1" />
+	<property name="Former Authors" value="inorixu,lemon42,smbarbour" />
+	<path id="classpath">
+		<fileset dir="lib" includes="**/*.jar" />
+	</path>
+	<target name="main" depends="prep, class, compile, jar, clean" description="Main target">
+		<echo>Building the .jar file.</echo>
+	</target>
 
-  <!-- compile -->
-  <target name="compile">
-      <echo>Compiling</echo>
-      <javac target="1.6" source="1.6" srcdir="src/com/" destdir="build" debug="true" debuglevel="lines,vars,source" classpathref="classpath" includeantruntime="false">
-      <compilerarg value="-Xbootclasspath/p:${toString:classpath}"/>
-      </javac>
-      <copy file="src/plugin.yml" tofile="build/plugin.yml"/>
-      <copy file="src/config.yml" tofile="build/config.yml"/>
-      <copy todir="build/languagefiles"><fileset dir="src/languagefiles"/></copy>  
-  </target>
-  
-  <!-- jar -->
-  <target name="jar" depends="compile">
-      <jar jarfile="dist/Residence.jar" basedir="build">
-    <manifest>
-      <attribute name="Residence" value="Dev Team: ${Authors} Former Dev Team: ${Former Authors}"/>
-      <attribute name="Version" value="${Ver}"/>
-      <attribute name="Built-By" value="${user.name}"/>
-    </manifest>
-      </jar>
-  </target>
+	<!-- Prep -->
+	<target name="prep" description="Initializes project">
+		<echo>Cleaning</echo>
+		<delete failonerror="false">
+			<fileset dir="build" includes="**/*" />
+		</delete>
+		<delete file="dist/Residence.jar" />
+		<tstamp />
+		<mkdir dir="dist" />
+		<mkdir dir="build" />
+		<mkdir dir="lib" />
+	</target>
+
+	<!-- Download and unzip libraries -->
+	<target name="class" description="Install third-party support libraries and plugins">
+		<get src="http://www.whiskeycraft.net/repo/org/spout/spoutapi/spoutpluginapi.jar" dest="lib/SpoutpluginAPI.jar" />
+		<get src="http://dev.bukkit.org/media/files/658/548/Essentials.zip" dest="lib/Essentials.zip" />
+		<!--essentials core -->
+		<get src="http://cloud.github.com/downloads/essentials/Essentials/Essentials-gm-2.9.5.zip" dest="lib/GroupManager.zip" />
+		<!-- essentials group manager and bridge-->
+		<get src="http://dl.bukkit.org/latest-dev/bukkit.jar" dest="lib/Bukkit.jar" />
+		<get src="http://palmergames.com/downloads/iCo501/iConomy.jar" dest="lib/iConomy5.jar" />
+		<get src="http://dev.bukkit.org/media/files/575/485/iConomy.jar" dest="lib/iConomy6.jar" />
+		<get src="http://www.whiskeycraft.net/repo/com/nijikokun/bukkit/permissions/Permissions.jar" dest="lib/Permissions.jar" />
+		<get src="http://www.whiskeycraft.net/repo/com/platymuus/bukkit-permissions/1.5/bukkit-permissions-1.5.jar" dest="lib/PermissionsBukkit.jar" />
+		<get src="http://dev.bukkit.org/media/files/656/592/Vault.jar" dest="lib/Vault.jar" />
+		<get src="http://dev.bukkit.org/media/files/644/439/worldedit-5.4.5.zip" dest="lib/WorldEdit.zip" />
+		<get src="http://dev.bukkit.org/media/files/577/409/BOSEcon0731.zip" dest="lib/BOSEconomy.zip" />
+		<get src="http://dev.bukkit.org/media/files/644/317/RealPlugin.jar" dest="lib/RealPlugin.jar" />
+		<get src="http://dev.bukkit.org/media/files/610/407/bpermissions.jar" dest="lib/bPermissions.jar" />
+		<unzip src="lib/BOSEconomy.zip" dest="lib/">
+		</unzip>
+		<delete file="lib/BOSEconomy.zip" />
+		<unzip src="lib\Essentials.zip" dest="lib\Essentials.jar">
+			<patternset>
+				<include name="Essentials.jar" />
+			</patternset>
+		</unzip>
+		<unzip src="lib\GroupManager.zip" dest="lib\">
+			<patternset>
+				<include name="*.jar" />
+			</patternset>
+		</unzip>
+		<unzip src="lib\WorldEdit.zip" dest="lib\">
+			<patternset>
+				<include name="*.jar" />
+			</patternset>
+		</unzip>
+	</target>
+
+	<!-- compile -->
+	<target name="compile" description="Compile Residence source">
+		<echo>Compiling</echo>
+		<javac target="1.6" source="1.6" srcdir="src/com/" destdir="build" debug="true" debuglevel="lines,vars,source" classpathref="classpath" includeantruntime="false">
+			<compilerarg value="-Xbootclasspath/p:${toString:classpath}" />
+		</javac>
+		<copy file="src/plugin.yml" tofile="build/plugin.yml" />
+		<copy file="src/config.yml" tofile="build/config.yml" />
+		<copy todir="build/languagefiles">
+			<fileset dir="src/languagefiles" />
+		</copy>
+	</target>
+
+	<!-- jar -->
+	<target name="jar" description="Packages JAR distribution">
+		<echo>Packaging JAR distribution</echo>
+		<jar jarfile="dist/Residence.jar" basedir="build">
+			<manifest>
+				<attribute name="Residence" value="Dev Team: ${Authors} Former Dev Team: ${Former Authors}" />
+				<attribute name="Version" value="${Ver}" />
+				<attribute name="Built-By" value="${user.name}" />
+			</manifest>
+		</jar>
+	</target>
+
+	<!-- clean -->
+	<target name="clean" description="Clean up project">
+		<echo>Cleaning up</echo>
+		<delete dir="build" />
+		<delete dir="lib" />
+	</target>
 </project>

--- a/src/com/bekvon/bukkit/residence/event/ResidenceChangedEvent.java
+++ b/src/com/bekvon/bukkit/residence/event/ResidenceChangedEvent.java
@@ -5,22 +5,66 @@ import org.bukkit.event.HandlerList;
 
 import com.bekvon.bukkit.residence.protection.ClaimedResidence;
 
+/**
+ * The {@link ResidenceChangedEvent} is fired when a player transitions between residences and/or
+ * residence subzones. Possible transitions include:
+ * <ul>
+ * <li>Moving from no residence into a residence/subzone;</li>
+ * <li>Moving from a residence/subzone to no residence; or</li>
+ * <li>Moving between residences/subzones</li>
+ * </ul>
+ * <p>
+ * {@link ResidenceChangedEvent} is a replacement for {@link ResidenceEnterEvent} and
+ * {@link ResidenceLeaveEvent}, which have been marked as deprecated and will be removed in future
+ * releases. Using this event benefits developers as it encapsulates enter/leave conditions in a
+ * single event and doesn't require additional correlation to detect and residence-to-residence
+ * transition.
+ * <p/>
+ * <p>
+ * This event is fired whenever conditions are met when a player moves or teleports to a new
+ * location. The event is also triggered when players appear in a residence upon logging in.
+ * 
+ * @author frelling
+ *
+ */
 public class ResidenceChangedEvent extends ResidencePlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     
     private ClaimedResidence from = null;
     private ClaimedResidence to = null;
 
+    /**
+     * Constructs a {@link ResidenceChangedEvent} to identify a residence transition for the
+     * given player
+     * 
+     * @param from the residence that the player left or {@code null} if coming from an
+     * unprotected area.
+     * @param to the residence that the player entered or {@code null} if entering an
+     * unprotected area.
+     * @param player player involved in the transition
+     */
     public ResidenceChangedEvent(ClaimedResidence from, ClaimedResidence to, Player player) {
         super("RESIDENCE_CHANGE", null, player);
         this.from = from;
         this.to = to;
     }
     
+    /**
+     * Returns the residence from which player came.
+     * 
+     * @return the residence from which player came or {@code null} if player came from an
+     * unprotected area
+     */
     public ClaimedResidence getFrom() {
     	return from;
     }
     
+    /**
+     * Returns the residence that player has entered.
+     * 
+     * @return the residence that player has entered or {@code null} if player enters an
+     * unprotected area
+     */
     public ClaimedResidence getTo() {
     	return to;
     }

--- a/src/com/bekvon/bukkit/residence/event/ResidenceEnterEvent.java
+++ b/src/com/bekvon/bukkit/residence/event/ResidenceEnterEvent.java
@@ -4,16 +4,21 @@
  */
 
 package com.bekvon.bukkit.residence.event;
-import org.bukkit.ChatColor;
 
 import com.bekvon.bukkit.residence.protection.ClaimedResidence;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 
 /**
- *
+ * Note: This event has been replaced with {@link ResidenceChangedEvent} and is marked as
+ * deprecated as of 21-MAY-2013. It will be removed in future releases. Please see
+ * {@link ResidenceChangedEvent} comments for further information.
+ * 
+ * TODO - Remove this class at a suitable time in the future.
+ * 
  * @author Administrator
  */
+@Deprecated
 public class ResidenceEnterEvent extends ResidencePlayerEvent {
 
     private static final HandlerList handlers = new HandlerList();

--- a/src/com/bekvon/bukkit/residence/event/ResidenceLeaveEvent.java
+++ b/src/com/bekvon/bukkit/residence/event/ResidenceLeaveEvent.java
@@ -4,16 +4,21 @@
  */
 
 package com.bekvon.bukkit.residence.event;
-import org.bukkit.ChatColor;
 
 import com.bekvon.bukkit.residence.protection.ClaimedResidence;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 
 /**
- *
+ * Note: This event has been replaced with {@link ResidenceChangedEvent} and is marked as
+ * deprecated as of 21-MAY-2013. It will be removed in future releases. Please see
+ * {@link ResidenceChangedEvent} comments for further information.
+ * 
+ * TODO - Remove this class at a suitable time in the future.
+ * 
  * @author Administrator
  */
+@Deprecated
 public class ResidenceLeaveEvent extends ResidencePlayerEvent {
 
     private static final HandlerList handlers = new HandlerList();

--- a/src/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
+++ b/src/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
@@ -428,10 +428,18 @@ public class ResidencePlayerListener implements Listener {
             lastOutsideLoc.put(pname, loc);
             if (ResOld != null) {
                 String leave = ResOld.getLeaveMessage();
+                /*
+                 * TODO - ResidenceLeaveEvent is deprecated as of 21-MAY-2013. Its functionality is replaced by
+                 * ResidenceChangedEvent. For now, this event is still supported until it is removed at a
+                 * suitable time in the future.
+                 */
                 ResidenceLeaveEvent leaveevent = new ResidenceLeaveEvent(ResOld, player);
-                ResidenceChangedEvent chgEvent = new ResidenceChangedEvent(ResOld, null, player);
                 Residence.getServ().getPluginManager().callEvent(leaveevent);
+                
+                // New ResidenceChangeEvent
+                ResidenceChangedEvent chgEvent = new ResidenceChangedEvent(ResOld, null, player);
                 Residence.getServ().getPluginManager().callEvent(chgEvent);
+                
                 if (leave != null && !leave.equals("")) {
                     player.sendMessage(ChatColor.YELLOW + this.insertMessages(player, ResOld.getName(), ResOld, leave));
                 }
@@ -459,21 +467,38 @@ public class ResidencePlayerListener implements Listener {
                 chatchange = true;
             }
             
+            // "from" residence for ResidenceChangedEvent
             ClaimedResidence chgFrom = null;
             if (ResOld != res && ResOld != null) {
                 String leave = ResOld.getLeaveMessage();
                 chgFrom = ResOld;
+                
+                /*
+                 * TODO - ResidenceLeaveEvent is deprecated as of 21-MAY-2013. Its functionality is replaced by
+                 * ResidenceChangedEvent. For now, this event is still supported until it is removed at a
+                 * suitable time in the future.
+                 */
                 ResidenceLeaveEvent leaveevent = new ResidenceLeaveEvent(ResOld, player);
                 Residence.getServ().getPluginManager().callEvent(leaveevent);
+                
                 if (leave != null && !leave.equals("") && ResOld != res.getParent()) {
                     player.sendMessage(ChatColor.YELLOW + this.insertMessages(player, ResOld.getName(), ResOld, leave));
                 }
             }
             String enterMessage = res.getEnterMessage();
+            
+            /*
+             * TODO - ResidenceEnterEvent is deprecated as of 21-MAY-2013. Its functionality is replaced by
+             * ResidenceChangedEvent. For now, this event is still supported until it is removed at a
+             * suitable time in the future.
+             */
             ResidenceEnterEvent enterevent = new ResidenceEnterEvent(res, player);
-            ResidenceChangedEvent chgEvent = new ResidenceChangedEvent( chgFrom, res, player);
             Residence.getServ().getPluginManager().callEvent(enterevent);
+            
+            // New ResidenceChangedEvent
+            ResidenceChangedEvent chgEvent = new ResidenceChangedEvent( chgFrom, res, player);
             Residence.getServ().getPluginManager().callEvent(chgEvent);
+            
             if (enterMessage != null && !enterMessage.equals("") && !(ResOld != null && res == ResOld.getParent())) {
                 player.sendMessage(ChatColor.YELLOW + this.insertMessages(player, areaname, res, enterMessage));
             }


### PR DESCRIPTION
Greetings once more:

Thanks for taking the time to get ResidenceEnter/Leave events working properly. It is much appreciate. They are working like a charm. As you may have garnered from my previous comments, we have been working on expanding our internal permissions system to allow residence-specific permissions and/or permission groups.

While working on that project, we've come to realize that individual leave and enter events are not that conducive when working with all but the simplest residences. Residences with several levels of subzones quickly turn zone transition evaluations into a cumbersome task because there is no direct correlation between leave and enter events.

Instead, we chose to follow along similar lines as the PlayerMove event, by creating a ResidenceChangedEvent containing references to both the residence being left and the residence being entered. Obviously, either of these could be null if there is no originating or destination residence, in essence resembling ResidenceEnter/Leave event. We hope that you see it fit to include this additional event in your build.
