### PR TITLE
Make sure players can use flint and steel to ignite fires when they have...

### DIFF
--- a/src/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
+++ b/src/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
@@ -203,9 +203,10 @@ public class ResidenceBlockListener implements Listener {
         		event.setCancelled(true);
         		player.sendMessage(ChatColor.RED+Residence.getLanguage().getPhrase("NoPermission"));
         	}
-        }
-        if(!perms.has("ignite", true)){
-            event.setCancelled(true);
+        } else {
+        	if(!perms.has("ignite", true)){
+        	    event.setCancelled(true);
+        	}
         }
     }
 }


### PR DESCRIPTION
... permission

The previous commit for NPE changed behavior such that a player can't light fires in his own residence
